### PR TITLE
CHECKOUT-3079: Enable `cyclomatic-complexity` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -49,7 +49,7 @@
             "check-space"
         ],
         "curly": true,
-        "cyclomatic-complexity": false,
+        "cyclomatic-complexity": true,
         "eofline": true,
         "forin": true,
         "import-spacing": true,


### PR DESCRIPTION
## What?
* Enable `cyclomatic-complexity` rule
* **BREAKING CHANGE**: Your linter now complains if your code exceeds the cyclomatic complexity threshold.

## Why?
* To set a limit on code complexity. Please see https://palantir.github.io/tslint/rules/cyclomatic-complexity/ for more information.

## Testing / Proof
* None

@bigcommerce/frontend
