### PR TITLE
CHECKOUT-3079: Enable `no-any` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -85,7 +85,7 @@
         ],
         "new-parens": true,
         "no-angle-bracket-type-assertion": true,
-        "no-any": false,
+        "no-any": true,
         "no-arg": true,
         "no-bitwise": true,
         "no-conditional-assignment": true,


### PR DESCRIPTION
## What?
* Enable `no-any` rule
* **BREAKING CHANGE**: Your linter now complains if your code uses `any` type.

## Why?
* Using `any` defeats the purpose of using TypeScript. Please see https://palantir.github.io/tslint/rules/no-any/ for the rationale.

## Testing / Proof
* None

@bigcommerce/frontend
