### PR TITLE
CHECKOUT-3079: Enable `no-non-null-assertion` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -104,6 +104,7 @@
             true,
             "allow-declarations"
         ],
+        "no-non-null-assertion": true,
         "no-parameter-properties": false,
         "no-reference": true,
         "no-reference-import": true,


### PR DESCRIPTION
## What?
* Enable `no-non-null-assertion` rule. 
* **BREAKING CHANGE**: Using `!` assertion is now considered to be an error.

## Why?
* Using non-null assertion cancels the benefits of the strict null checking mode. (https://palantir.github.io/tslint/rules/no-non-null-assertion/)

## Testing / Proof
* None

@bigcommerce/frontend
