### PR TITLE
CHECKOUT-3079: Enable `newline-per-chained-call` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -84,6 +84,7 @@
             }
         ],
         "new-parens": true,
+        "newline-per-chained-call": true,
         "no-angle-bracket-type-assertion": true,
         "no-any": false,
         "no-arg": true,


### PR DESCRIPTION
## What?
* Enable `newline-per-chained-call` rule
* **BREAKING CHANGE**: Chained method calls now need to be broken apart onto
separate lines.

## Why?
* https://palantir.github.io/tslint/rules/newline-per-chained-call/

## Testing / Proof
* None

@bigcommerce/frontend
