### PR TITLE
CHECKOUT-3079 Enable `newline-before-return` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -84,6 +84,7 @@
             }
         ],
         "new-parens": true,
+        "newline-before-return": true,
         "newline-per-chained-call": true,
         "no-angle-bracket-type-assertion": true,
         "no-any": false,


### PR DESCRIPTION
## What?
* Enable `newline-before-return` rule 
* **BREAKING CHANGE:** You must now have a blank line before any `return` statement.

## Why?
* It helps with readability. https://palantir.github.io/tslint/rules/newline-before-return/

## Testing / Proof
* None

@bigcommerce/frontend
