### PR TITLE
CHECKOUT-3079: Enable `prefer-method-signature` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -154,6 +154,7 @@
         ],
         "prefer-const": true,
         "prefer-for-of": true,
+        "prefer-method-signature": true,
         "quotemark": [
             true,
             "single",


### PR DESCRIPTION
## What?
* Enable `prefer-method-signature` rule 
* **BREAKING CHANGE**: You must now define methods as `foo(): void` in interfaces and types.

## Why?
* Better consistency. https://palantir.github.io/tslint/rules/prefer-method-signature/

## Testing / Proof
* None

@bigcommerce/frontend
