### PR TITLE
CHECKOUT-3092 Enable `no-unnecessary-type-assertion` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -115,6 +115,7 @@
         "no-switch-case-fall-through": false,
         "no-trailing-whitespace": true,
         "no-unnecessary-initializer": true,
+        "no-unnecessary-type-assertion": true,
         "no-unsafe-finally": true,
         "no-unused-expression": true,
         "no-unused-variable": true,


### PR DESCRIPTION
## What?
* Enable `no-unnecessary-type-assertion` rule
* **BREAKING CHANGE:** Throw an error if there is an unnecessary type assertion.

## Why?
* Avoid redundancy. https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/

## Testing / Proof
* None

@bigcommerce/frontend
