### PR TITLE
CHECKOUT-3079: Enable `match-default-export-name` rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -65,6 +65,7 @@
         "interface-over-type-literal": true,
         "jsdoc-format": true,
         "label-position": true,
+        "match-default-export-name": true,
         "max-classes-per-file": [
             true,
             1


### PR DESCRIPTION
## What?
* Enable `match-default-export-name` rule
* **BREAKING CHANGE:** Default modules must be imported and exported with the same name.

## Why?
* Better consistency. https://palantir.github.io/tslint/rules/match-default-export-name/
* The following code is considered to be an error.
```ts
// foobar.ts
export default class Foobar {}

// main.ts
import Bob from './foobar'; // Error: You should call it `Foobar` because the exported module is called `Foobar`.
```

## Testing / Proof
* None

@bigcommerce/frontend
