### PR TITLE
MERC-3541 Remove newline-per-chained-call rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -86,7 +86,7 @@
         ],
         "new-parens": true,
         "newline-before-return": true,
-        "newline-per-chained-call": true,
+        "newline-per-chained-call": false,
         "no-angle-bracket-type-assertion": true,
         "no-any": false,
         "no-arg": true,


### PR DESCRIPTION
Curious how everyone would feel about this change. I definitely think it's generally a good style to follow, but I find it a little restrictive not to be able to do stuff like

`expect(blah).toEqual(blah)`

Unfortunately it doesn't look like tslint supports the `ignoreChainWithDepth` option that eslint does, so it seems to be all or nothing.

@bigcommerce/frontend
