### PR TITLE
fix(common): MERC-3598 Allow tagged template literals

### DIFF
--- a/index.json
+++ b/index.json
@@ -118,7 +118,7 @@
         "no-unnecessary-initializer": true,
         "no-unnecessary-type-assertion": true,
         "no-unsafe-finally": true,
-        "no-unused-expression": true,
+        "no-unused-expression": [true, "allow-tagged-template"],
         "no-unused-variable": true,
         "no-var-keyword": true,
         "no-var-requires": true,


### PR DESCRIPTION
## What?
Exempt tagged template literals from the `no-unsued-expression` rule. 
This will allow usecases such as:

```javascript
import { injectGlobal } from 'styled-components';

injectGlobal`
  @font-face {
    font-family: 'Operator Mono';
    src: url('../fonts/Operator-Mono.ttf');
  }

  body {
    margin: 0;
  }
`;
```

## Why?
Because we will be using styled-components in the future, which heavily leverages tagged template literals

## Testing / Proof
manual

@bigcommerce/frontend
