### PR TITLE
CHECKOUT-3790: Make sure trailing comma is ES compliant

### DIFF
--- a/index.json
+++ b/index.json
@@ -189,7 +189,8 @@
                     "objects": "always",
                     "typeLiterals": "always"
                 },
-                "singleline": "never"
+                "singleline": "never",
+                "esSpecCompliant": true
             }
         ],
         "triple-equals": [


### PR DESCRIPTION
## What?
* Make sure trailing comma is ES compliant

## Why?
* If you add a trailing comma after a rest parameter, TypeScript will not compile because it's not ES compliant. Please see https://blogs.msdn.microsoft.com/typescript/2018/05/31/announcing-typescript-2-9/ for more information.

## Testing / Proof
* Manual

@bigcommerce/frontend
