### PR TITLE
FE-33 Remove no-unused-variable since it is deprecated

### DIFF
--- a/index.json
+++ b/index.json
@@ -120,7 +120,6 @@
         "no-unnecessary-type-assertion": true,
         "no-unsafe-finally": true,
         "no-unused-expression": [true, "allow-tagged-template"],
-        "no-unused-variable": true,
         "no-var-keyword": true,
         "no-var-requires": true,
         "object-literal-key-quotes": [


### PR DESCRIPTION
Please enable `noUnusedLocals` and `noUnusedParameters` in your `tsconfig.json` file.

```js
...
"noUnusedLocals": true,
"noUnusedParameters": true,
...
```

## What?
- Remove no-unused-variable

## Why?
- Because it is deprecated

## Testing / Proof
- N/A

@bigcommerce/frontend
