### PR TITLE
FE-40 Prevent tslint from processing json files

### DIFF
--- a/index.json
+++ b/index.json
@@ -233,5 +233,11 @@
             "check-type",
             "check-typecast"
         ]
+    },
+    "linterOptions": {
+        "exclude": [
+            "*.json",
+            "**/*.json"
+        ]
     }
 }


### PR DESCRIPTION
## What?
- As per title

## Why?
- Tslint will otherwise try to process json files as if they were TS files thus throwing countless errors.

## Testing / Proof
- Manual

### Before
<img width="691" alt="image" src="https://user-images.githubusercontent.com/4542735/58922177-2b61c400-877d-11e9-949f-85da18cbd031.png">

@bigcommerce/frontend
