### PR TITLE
CHECKOUT-4231 no-duplicate-imports & more strict whitespaces

### DIFF
--- a/index.json
+++ b/index.json
@@ -230,9 +230,14 @@
             "check-branch",
             "check-decl",
             "check-operator",
+            "check-module",
             "check-separator",
+            "check-rest-spread",
             "check-type",
-            "check-typecast"
+            "check-typecast",
+            "check-type-operator",
+            "check-preblock",
+            "check-postbrace"
         ]
     }
 }

--- a/index.json
+++ b/index.json
@@ -96,6 +96,7 @@
         "no-console": true,
         "no-construct": true,
         "no-debugger": true,
+        "no-duplicate-imports": true,
         "no-duplicate-super": true,
         "no-empty": true,
         "no-empty-interface": true,


### PR DESCRIPTION
## What?
- `no-duplicate-imports` Disallows multiple import statements from the same module.
- `check-module` checks for whitespace in `import` & `export` statements.
- `check-rest-spread` checks that there is no whitespace after rest/spread operator (`...`).
- `check-typecast` checks for whitespace between a typecast and its target.
- `check-type-operator` checks for whitespace between type operators `|` and `&`.
- `check-preblock` checks for whitespace before the opening brace of a block.
- `check-postbrace` checks for whitespace after an opening brace.

## Why?
- A more strict tslint results in less time reviewing code styling issues.

## Testing / Proof
- Manual

@bigcommerce/frontend
