### PR TITLE
CHECKOUT-4321 no-async-without-await & enfoce `;` as the type terminator

### DIFF
--- a/index.json
+++ b/index.json
@@ -198,6 +198,9 @@
             true,
             "allow-null-check"
         ],
+        "type-literal-delimiter": {
+            "singleLine": "always"
+        },
         "typedef": false,
         "typedef-whitespace": [
             true,

--- a/index.json
+++ b/index.json
@@ -90,6 +90,7 @@
         "no-angle-bracket-type-assertion": true,
         "no-any": false,
         "no-arg": true,
+        "no-async-without-await": true,
         "no-bitwise": true,
         "no-conditional-assignment": true,
         "no-consecutive-blank-lines": true,

--- a/index.json
+++ b/index.json
@@ -240,8 +240,7 @@
             "check-type",
             "check-typecast",
             "check-type-operator",
-            "check-preblock",
-            "check-postbrace"
+            "check-preblock"
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "standard-version": "^4.3.0"
   },
   "peerDependencies": {
-    "tslint": "^5.9.1"
+    "tslint": "^5.18.0"
   }
 }


### PR DESCRIPTION
## What?
- Remove `check-postbrace` from the `whitespace` rule
- `no-async-without-await` Functions marked async must contain an await or return statement.
- `type-literal-delimiter` Checks that type literal members are separated by semicolons. Enforces a trailing semicolon for multiline type literals.

## Why?
- More rules, less comments in PRs
- The `check-postbrace` causes `{}` to be invalid. We don't want to write `{ }`.

## Testing / Proof
- Manual

@bigcommerce/frontend
