### PR TITLE
CHECKOUT-4136 Exclude json files no matter where tslint is placed

### DIFF
--- a/index.json
+++ b/index.json
@@ -245,8 +245,7 @@
     },
     "linterOptions": {
         "exclude": [
-            "*.json",
-            "**/*.json"
+            "/**/*.json"
         ]
     }
 }


### PR DESCRIPTION
## What?
Add a `/` to the json exclude pattern

## Why?
The `exclude` pattern is based on the directory where tslint is placed.
If we want to exclude json files regardless of the location of tslint.json
we need to specify a `/` so all files, no matter the location are excluded.

## Testing / Proof
- Manual

Before:
<img width="819" alt="image" src="https://user-images.githubusercontent.com/4542735/61270778-fd44ba80-a7e5-11e9-9baa-25ce547a775f.png">

After:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/4542735/61270714-cd95b280-a7e5-11e9-82d2-6804a3f4a9fb.png">


@bigcommerce/frontend
