### PR TITLE
feat(common): CHP-6324 Disable object-literal-sort-keys

### DIFF
--- a/index.json
+++ b/index.json
@@ -129,7 +129,7 @@
             "as-needed"
         ],
         "object-literal-shorthand": true,
-        "object-literal-sort-keys": true,
+        "object-literal-sort-keys": false,
         "one-line": [
             true,
             "check-catch",


### PR DESCRIPTION
## What?
Disable `object-literal-sort-keys`

## Why?
Per a discussion in https://github.com/bigcommerce/staff-center-ui/pull/2#discussion_r388236220, disabling since most people are doing that.

## Testing / Proof
No need?

@bigcommerce/frontend
